### PR TITLE
adding CSS selector to enable modal footer wrap

### DIFF
--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -73,6 +73,10 @@
       }
     }
 
+    .modal-footer {
+      display: block; // because CSS modules won't render the style w/o a defined selector
+    }
+
     .modal-actions {
       margin-top: 24px;
       float: right;


### PR DESCRIPTION
So the CSS module import `className['modal-footer']` will appear in the DOM