### PR TITLE
Added onBlur listener for InlineEdit component (saves on blur, i.e. tab-out)

### DIFF
--- a/src/components/InlineEdit/InlineEdit.js
+++ b/src/components/InlineEdit/InlineEdit.js
@@ -132,6 +132,7 @@ class InlineEdit extends React.Component {
   componentDidMount = () => {
     if (this.props.type === 'text') {
       this.attachKeyListeners()
+      this.attachKeyListeners()
       this.activateCopyToClipboard()
     }
     this.getStyles()
@@ -306,6 +307,14 @@ class InlineEdit extends React.Component {
     this._textValue.addEventListener('keypress', this.handleKeyPress)
     this._textValue.addEventListener('keyup', this.handleKeyUp)
   }
+
+  attachBlurListener = function () {
+    this._textValue.addEventListener('blur', event => {
+      event.preventDefault()
+      this.handleSave()
+    });
+  }
+
 
   handleKeyPress = event => {
     // Grabs the character code, even in FireFox


### PR DESCRIPTION
Hi. I'm a newbie programmer so forgive my ignorance but this is my first pull request.

Originally I simply npm-installed your repo then added the above changes to it. This worked fine. however I am aware that npm install will override my modified files with your originals so I thought forking would solve this?

So I forked the repo, modified the files,  uninstalled your original repo, installed my fork from github and then get errors along the lines of: `You may need an appropriate loader to handle this file type.`

Obviously I need to build the package somehow but that is beyond me... Tried all the npm scripts in your package.json but none work (similar errors as above). Would love some advice as to how to use my newly modified fork?

Anyway, my changes appear to be fine, what happens now? 

Cheers,

Mick.