### PR TITLE
buttonconfirmation wide

### DIFF
--- a/src/components/Button/ButtonConfirmation.js
+++ b/src/components/Button/ButtonConfirmation.js
@@ -46,7 +46,11 @@ export class ButtonConfirmation extends Component {
     /**
      * Function used to pass up the confirmation to the parent component
      */
-    handleConfirmation: PropTypes.func
+    handleConfirmation: PropTypes.func,
+    /**
+     * Whether the prompt should be wide
+     */
+    wide: PropTypes.bool
   }
 
   state = {
@@ -88,7 +92,7 @@ export class ButtonConfirmation extends Component {
   }
 
   handleWide = () => {
-    if (this.props.prompt.length > 25) {
+    if (this.props.wide || this.props.prompt.length > 25) {
       this.setState({ wide: true })
     }
   }


### PR DESCRIPTION
- [x] Review code
- [x] Go to http://localhost:3000/components/buttons
- [x] Scroll to Button with Confirmation
- [x] Open `Left` and inspect the `confirmation-overlay`
- [x] The width is 160px (default)
- [x] In ~SublimeText~ VSCode, go to this file and on this line add a `wide` prop: https://github.com/GetAmbassador/react-ions/blob/master/docs/src/app/pages/components/Buttons/ExampleButtonConfirmation.js#L8
- [x] Refresh the page
- [x] Open `Left` and inspect the `confirmation-overlay`
- [x] The width is 200px (wide)